### PR TITLE
fix: clean up product manager instruction bullet

### DIFF
--- a/src/ai-providers/data/systemInstruction.ts
+++ b/src/ai-providers/data/systemInstruction.ts
@@ -12,7 +12,7 @@ Your response should ONLY include the summary of the PR.
 Your summary should contain these things:
 1. **Change Description:** A brief, one sentence description of all the changes.
 2. **Key Technical Changes:** A list of all of the most important technical changes this PR introduces.
-3. **Potential Risks ans Suggestions:* (Optional) If you'll see something worth pointing out.
+3. **Potential Risks and Suggestions:** (Optional) If you'll see something worth pointing out.
 `;
 
 export const systemInstructionTechLead: SystemInstruction = `


### PR DESCRIPTION
## Summary
- fix typo and markdown in potential risks bullet

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689511c840508323902eeac6e711967b