### PR TITLE
Add tests for config JSON parsing

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ const githubSchema = z.object({
   full_name: z.string(),
 });
 
-const stringToJson = z
+export const stringToJson = z
   .string()
   .transform((str, ctx): z.infer<typeof githubSchema> => {
     try {
@@ -26,8 +26,8 @@ const schema = z.object({
   REPO_CONTEXT: stringToJson.pipe(githubSchema),
 });
 
-const parsedSchema: z.infer<typeof schema> = schema.parse(process.env);
-
-export function getConfig(): typeof parsedSchema {
-  return parsedSchema;
+export function getConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): z.infer<typeof schema> {
+  return schema.parse(env);
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,19 @@
+import { expect, test, describe } from "bun:test";
+import { stringToJson } from "../src/config.ts";
+
+describe("stringToJson", () => {
+  test("parses valid JSON strings into objects", () => {
+    const json = '{"full_name":"octocat/Hello-World"}';
+    const result = stringToJson.parse(json);
+    expect(result).toEqual({ full_name: "octocat/Hello-World" });
+  });
+
+  test("reports Invalid JSON on malformed input", () => {
+    const invalid = "{full_name:}";
+    const result = stringToJson.safeParse(invalid);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("Invalid JSON");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- export `stringToJson` and lazy `getConfig` parsing
- cover JSON parsing success and failure cases

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68951364fb348323aecee3138982b5fb