### PR TITLE
chore: throw error for missing repo context

### DIFF
--- a/src/github.service.ts
+++ b/src/github.service.ts
@@ -12,9 +12,7 @@ export class GithubService {
 
     const [owner, repo] = REPO_CONTEXT.full_name.split("/");
     if (!owner || !repo) {
-      console.error("Missing owner or repo name.");
-
-      return;
+      throw new Error("Missing owner or repo name.");
     }
 
     this.prNumber = PR_NUMBER;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,14 @@ import { GeminiStrategy } from "./ai-providers/gemini.strategy.ts";
 import { systemInstructionPM } from "./ai-providers/data/systemInstruction.ts";
 
 async function main(): Promise<void> {
-  const githubService = new GithubService();
+  let githubService: GithubService;
+  try {
+    githubService = new GithubService();
+  } catch (error) {
+    console.error(error);
+
+    return;
+  }
   const aiProviderContext = new AiProviderContext(new GeminiStrategy(), {
     systemInstruction: systemInstructionPM,
   });


### PR DESCRIPTION
## Summary
- throw error when repo context is missing
- handle GithubService initialization failure
- insert spacing before returning on init error

## Testing
- `bun run format`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895133a54a0832395b5b6209499155a